### PR TITLE
Set InterpolateContext

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -51,7 +51,8 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	var errs *packer.MultiError
 
 	err := hconfig.Decode(&self.config, &hconfig.DecodeOpts{
-		Interpolate: true,
+		Interpolate:        true,
+		InterpolateContext: &self.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"boot_command",

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -39,7 +39,8 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	var errs *packer.MultiError
 
 	err := hconfig.Decode(&self.config, &hconfig.DecodeOpts{
-		Interpolate: true,
+		Interpolate:        true,
+		InterpolateContext: &self.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"boot_command",


### PR DESCRIPTION
Setting the `InterpolateContext` fills out `config.ctx` in the builder to be passed into the steps that require it. For example, this allows user variables in the `boot_command` to be interpolated correctly.