### PR TITLE
Support instant provisioning from VM templates

### DIFF
--- a/builder/xenserver/common/step_convert_to_template.go
+++ b/builder/xenserver/common/step_convert_to_template.go
@@ -33,6 +33,18 @@ func (self *StepConvertToTemplate) Run(state multistep.StateBag) multistep.StepA
 		return multistep.ActionHalt
 	}
 
+	err = instance.AddToOtherConfig("instant", "true")
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error adding 'instant' to template's other_config: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = instance.RemoveFromOtherConfig("disks")
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error removing 'disks' from template's other_config: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
 	return multistep.ActionContinue
 }
 

--- a/vendor/github.com/xenserver/go-xenserver-client/vm.go
+++ b/vendor/github.com/xenserver/go-xenserver-client/vm.go
@@ -549,6 +549,24 @@ func (self *VM) SetOtherConfig(other_config map[string]string) (err error) {
 	return
 }
 
+func (self *VM) AddToOtherConfig(key string, value string) (err error) {
+	result := APIResult{}
+	err = self.Client.APICall(&result, "VM.add_to_other_config", self.Ref, key, value)
+	if err != nil {
+		return err
+	}
+	return
+}
+
+func (self *VM) RemoveFromOtherConfig(key string) (err error) {
+	result := APIResult{}
+	err = self.Client.APICall(&result, "VM.remove_from_other_config", self.Ref, key)
+	if err != nil {
+		return err
+	}
+	return
+}
+
 func (self *VM) SetNameLabel(name_label string) (err error) {
 	result := APIResult{}
 	err = self.Client.APICall(&result, "VM.set_name_label", self.Ref, name_label)


### PR DESCRIPTION
Prior to this change instant provisiong of VMs from the template would not work. This affected the "Quick Create" button in XenCenter or any other programmatic use of the clone, provision, start API calls. This change matches the actions taken when converting to template with XenCenter.

Adding `instant` to other config comes directly from XenCenter: https://github.com/xenserver/xenadmin/blob/92b3dc839524497168305a9c3e8f77a37536ec16/XenAdmin/Commands/ConvertVMToTemplateCommand.cs#L82

I can't remember exactly how I figured out to remove the `disks` XML from other config as well as it was difficult to follow the xen-api OCaml code. IIRC I saw the difference by comparing output from `xe` between a Packer produced template and one converted from a VM using XenCenter. The only decent reference to what the disks XML is that I could find was https://github.com/xapi-project/xen-api/blob/fe3dacf19fa179dbe4aae57c1b4e83e8dfab52bc/scripts/examples/python/provision.py#L16-L19 which also suggests that templates created from an actual VM wouldn't have it.